### PR TITLE
feat: support bundle, method and class package filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Configuration
 Following are the configuration options you can provide to the launcher:
 
 * `-out <path-to-file>` - write a test results XML file
+* `-bundle <bundle-symbolic-name>` - add a bundle to search for test classes in (if none is specified then all bundles are searched)
 * `-class <pattern>` - add a class name pattern for tests to run (allows asterisk as wild card, e.g. `*MyTest`)
+* `-method <method-name>` - add a test method to run in test classes - if specified only the given methods are run in test classes
 * `-unit` - adds the default pattern for unit tests (`*Test`)
 * `-integration` - adds the default pattern for integration tests (`*IT`)
 

--- a/de.fhg.igd.equinox.test.app/src/de/fhg/igd/equinox/test/app/TestClassAndMethods.java
+++ b/de.fhg.igd.equinox.test.app/src/de/fhg/igd/equinox/test/app/TestClassAndMethods.java
@@ -1,0 +1,58 @@
+// 
+// Copyright (c) 2022 wetransform GmbH
+//
+// This file is part of equinox-test.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package de.fhg.igd.equinox.test.app;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Associates a test class to test methods that should be run on the class.
+ */
+public class TestClassAndMethods {
+	
+	private final Class<?> testClass;
+	
+	private final Set<String> testMethods;
+
+	/**
+	 * 
+	 * @param testClass the test class
+	 * @param testMethods the test methods
+	 */
+	public TestClassAndMethods(Class<?> testClass, Collection<String> testMethods) {
+		super();
+		this.testClass = testClass;
+		this.testMethods = new TreeSet<String>(testMethods);
+	}
+
+	/**
+	 * @return the testClass
+	 */
+	public Class<?> getTestClass() {
+		return testClass;
+	}
+
+	/**
+	 * @return the testMethods
+	 */
+	public Set<String> getTestMethods() {
+		return testMethods;
+	}
+
+}

--- a/de.fhg.igd.equinox.test.app/src/de/fhg/igd/equinox/test/app/TestRunnerApplication.java
+++ b/de.fhg.igd.equinox.test.app/src/de/fhg/igd/equinox/test/app/TestRunnerApplication.java
@@ -45,6 +45,14 @@ public class TestRunnerApplication extends AbstractApplication<TestRunnerConfigI
 			// custom class pattern
 			executionContext.getClassPatterns().add(value);
 			break;
+		case "-bundle":
+			// limit to specific bundles
+			executionContext.getBundles().add(value);
+			break;
+		case "-method":
+			// limit to specific methods
+			executionContext.getMethodNames().add(value);
+			break;
 		}
 	}
 

--- a/de.fhg.igd.equinox.test.app/src/de/fhg/igd/equinox/test/app/TestRunnerConfig.java
+++ b/de.fhg.igd.equinox.test.app/src/de/fhg/igd/equinox/test/app/TestRunnerConfig.java
@@ -20,6 +20,7 @@
 package de.fhg.igd.equinox.test.app;
 
 import java.io.File;
+import java.util.Collection;
 
 /**
  * Test runner configuration interface.
@@ -38,5 +39,15 @@ public interface TestRunnerConfig {
 	 * as wildcard)
 	 */
 	Iterable<String> getClassPatterns();
+	
+	/**
+	 * @return the names of the specific bundles to run test classes for, or empty
+	 */
+	Collection<String> getBundles();
+	
+	/**
+	 * @return the names of specific test methods to run, or empty 
+	 */
+	Collection<String> getMethodNames();
 
 }

--- a/de.fhg.igd.equinox.test.app/src/de/fhg/igd/equinox/test/app/TestRunnerConfigImpl.java
+++ b/de.fhg.igd.equinox.test.app/src/de/fhg/igd/equinox/test/app/TestRunnerConfigImpl.java
@@ -34,6 +34,10 @@ public class TestRunnerConfigImpl implements TestRunnerConfig {
 	
 	private final Set<String> classPatterns = new HashSet<>();
 	
+	private final Set<String> bundles = new HashSet<>();
+	
+	private final Set<String> methodNames = new HashSet<>();
+	
 	@Override
 	public File getOutputFile() {
 		return outputFile;
@@ -49,6 +53,16 @@ public class TestRunnerConfigImpl implements TestRunnerConfig {
 	@Override
 	public Set<String> getClassPatterns() {
 		return classPatterns;
+	}
+
+	@Override
+	public Set<String> getBundles() {
+		return bundles;
+	}
+
+	@Override
+	public Set<String> getMethodNames() {
+		return methodNames;
 	}
 
 }

--- a/de.fhg.igd.equinox.test.app/src/de/fhg/igd/equinox/test/app/runner/util/GlobUtil.java
+++ b/de.fhg.igd.equinox.test.app/src/de/fhg/igd/equinox/test/app/runner/util/GlobUtil.java
@@ -1,0 +1,110 @@
+package de.fhg.igd.equinox.test.app.runner.util;
+
+/**
+ * Convert a glob to a regular expression.
+ * 
+ * see https://stackoverflow.com/a/17369948/982265
+ */
+public class GlobUtil {
+	
+	/**
+	 * Converts a standard POSIX Shell globbing pattern into a regular expression
+	 * pattern. The result can be used with the standard {@link java.util.regex} API to
+	 * recognize strings which match the glob pattern.
+	 * <p/>
+	 * See also, the POSIX Shell language:
+	 * http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_13_01
+	 * 
+	 * @param pattern A glob pattern.
+	 * @return A regex pattern to recognize the given glob pattern.
+	 */
+	public static final String convertGlobToRegex(String pattern) {
+	    StringBuilder sb = new StringBuilder(pattern.length());
+	    int inGroup = 0;
+	    int inClass = 0;
+	    int firstIndexInClass = -1;
+	    char[] arr = pattern.toCharArray();
+	    for (int i = 0; i < arr.length; i++) {
+	        char ch = arr[i];
+	        switch (ch) {
+	            case '\\':
+	                if (++i >= arr.length) {
+	                    sb.append('\\');
+	                } else {
+	                    char next = arr[i];
+	                    switch (next) {
+	                        case ',':
+	                            // escape not needed
+	                            break;
+	                        case 'Q':
+	                        case 'E':
+	                            // extra escape needed
+	                            sb.append('\\');
+	                        default:
+	                            sb.append('\\');
+	                    }
+	                    sb.append(next);
+	                }
+	                break;
+	            case '*':
+	                if (inClass == 0)
+	                    sb.append(".*");
+	                else
+	                    sb.append('*');
+	                break;
+	            case '?':
+	                if (inClass == 0)
+	                    sb.append('.');
+	                else
+	                    sb.append('?');
+	                break;
+	            case '[':
+	                inClass++;
+	                firstIndexInClass = i+1;
+	                sb.append('[');
+	                break;
+	            case ']':
+	                inClass--;
+	                sb.append(']');
+	                break;
+	            case '.':
+	            case '(':
+	            case ')':
+	            case '+':
+	            case '|':
+	            case '^':
+	            case '$':
+	            case '@':
+	            case '%':
+	                if (inClass == 0 || (firstIndexInClass == i && ch == '^'))
+	                    sb.append('\\');
+	                sb.append(ch);
+	                break;
+	            case '!':
+	                if (firstIndexInClass == i)
+	                    sb.append('^');
+	                else
+	                    sb.append('!');
+	                break;
+	            case '{':
+	                inGroup++;
+	                sb.append('(');
+	                break;
+	            case '}':
+	                inGroup--;
+	                sb.append(')');
+	                break;
+	            case ',':
+	                if (inGroup > 0)
+	                    sb.append('|');
+	                else
+	                    sb.append(',');
+	                break;
+	            default:
+	                sb.append(ch);
+	        }
+	    }
+	    return sb.toString();
+	}
+
+}


### PR DESCRIPTION
...for test runs.

The new argument `-bundle` can be used to restrict executed tests to
specific bundles.
The argument `-class` now also supports including package names in the
class name.
The new argument `-method` can be used to restrict executed tests to
specific methods.

Main incentive for adding these additional options is being able to use
them to run or debug individual tests, because running JUnit Plug-in
tests from Eclipse can be very slow in newer Eclipse versions (for
instance in the hale studio development environment).

ING-2671